### PR TITLE
Analyse stdout instead of hdf5 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install pyblock
         pip install pyscf
     - name: Install package
       run: |

--- a/ipie/analysis/blocking.py
+++ b/ipie/analysis/blocking.py
@@ -17,7 +17,8 @@ import scipy.stats
 
 from ipie.analysis.autocorr import reblock_by_autocorr
 from ipie.analysis.extraction import (extract_data, extract_mixed_estimates,
-                                      extract_rdm, get_metadata, set_info)
+                                      extract_rdm, get_metadata, set_info,
+                                      extract_data_from_textfile)
 from ipie.utils.linalg import get_ortho_ao_mod
 from ipie.utils.misc import get_from_dict
 
@@ -323,6 +324,21 @@ def analyse_back_prop(files, start_time):
         columns = set_info(res, md)
         full.append(res)
     return pd.concat(full).sort_values("tau_bp")
+
+def reblock_minimal(files, start_block=0, verbose=False):
+    """Minimal blocking analysis using approximate autocorrelation time.
+
+    Parses from textfile.
+    """
+    reblocked = []
+    for f in files:
+        data = extract_data_from_textfile(f)[start_block:]
+        y = data["ETotal"].values
+        rb = reblock_by_autocorr(y, verbose=verbose)
+        rb['filename'] = f
+        reblocked.append(rb)
+    df = pd.concat(reblocked)
+    return df
 
 
 def analyse_estimates(files, start_time, multi_sim=False, av_tau=False, verbose=False):

--- a/ipie/analysis/blocking.py
+++ b/ipie/analysis/blocking.py
@@ -353,7 +353,6 @@ def analyse_estimates(files, start_time, multi_sim=False, av_tau=False, verbose=
         print(av.apply(numpy.real).to_string())
     else:
         for f in files:
-            print("filename = {}".format(f))
             md = get_metadata(f)
             read_rs = get_from_dict(md, ["psi", "read_rs"])
             step = get_from_dict(md, ["qmc", "nsteps"])
@@ -381,8 +380,6 @@ def analyse_estimates(files, start_time, multi_sim=False, av_tau=False, verbose=
 
         base = files[0].split("/")[-1]
         outfile = "analysed_" + base
-        fmt = lambda x: "{:13.8f}".format(x)
-        print(basic_av.to_string(index=False, float_format=fmt))
         with h5py.File(outfile, "w") as fh5:
             fh5["metadata"] = numpy.array(mds).astype("S")
             try:
@@ -392,6 +389,8 @@ def analyse_estimates(files, start_time, multi_sim=False, av_tau=False, verbose=
             except KeyError:
                 pass
             fh5["basic/headers"] = numpy.array(basic_av.columns.values).astype("S")
+
+    return basic_av
 
 
 def analyse_ekt_ipea(filename, ix=None, cutoff=1e-14, screen_factor=1):

--- a/ipie/analysis/extraction.py
+++ b/ipie/analysis/extraction.py
@@ -117,8 +117,8 @@ def set_info(frame, md):
         if trial is not None:
             frame["mu_T"] = trial.get("mu")
             frame["Nav_T"] = trial.get("nav")
-    else:
-        frame["E_T"] = trial.get("energy")
+    # else:
+        # frame["E_T"] = trial.get("energy")
     if system["name"] == "UEG":
         frame["rs"] = system.get("rs")
         frame["ecut"] = system.get("ecut")

--- a/ipie/analysis/extraction.py
+++ b/ipie/analysis/extraction.py
@@ -13,6 +13,23 @@ def extract_data_sets(files, group, estimator, raw=False):
         data.append(extract_data(f, group, estimator, raw))
     return pd.concat(data)
 
+def extract_data_from_textfile(filename):
+    output = []
+    start_collecting = False
+    header = ''
+    with open(filename, 'r') as f:
+        for line in f:
+            if 'End Time' in line:
+                break
+            if start_collecting and 'End Time' not in line:
+                data = [float(s) for s in line.split()]
+                output.append(data)
+            if 'Iteration' in line and ':' not in line:
+                header = line.split()
+                start_collecting = True
+    data = numpy.array(output)
+    results = pd.DataFrame({k: v for k, v in zip(header, data.T)})
+    return results
 
 def extract_data(filename, group, estimator, raw=False):
     fp = get_param(filename, ["propagators", "free_projection"])

--- a/ipie/analysis/tests/test_blocking.py
+++ b/ipie/analysis/tests/test_blocking.py
@@ -1,0 +1,123 @@
+import h5py
+import json
+import numpy as np
+import os
+import pytest
+
+from ipie.estimators.utils import H5EstimatorHelper
+from ipie.analysis.blocking import (
+        analyse_estimates,
+        reblock_minimal
+        )
+
+
+@pytest.mark.unit
+def test_analyse_estimates():
+    np.random.seed(7)
+    nestim = 11
+    nblock = 500
+    data = np.random.random((nblock, nestim)) + 1j*np.random.random((nblock, nestim))
+    header = [
+        "Iteration",
+        "WeightFactor",
+        "Weight",
+        "ENumer",
+        "EDenom",
+        "ETotal",
+        "E1Body",
+        "E2Body",
+        "EHybrid",
+        "Overlap",
+        "Time",
+    ]
+    # fake some data
+    metadata = {
+            'system': {
+                'nbasis': 1,
+                'name': 'Generic',
+                'nup': 1,
+                'ndown': 1,
+                'integral_file': 'none'
+                },
+            'qmc': {
+                'nsteps': 1,
+                'dt': 0.05
+                },
+            'propagators': {
+                'free_projection': False
+                },
+            'trial': {
+                'energy': -1.0
+                }
+            }
+    with h5py.File('test.h5', 'w') as fh5:
+        fh5["basic/headers"] = np.array(header).astype("S")
+        fh5["metadata"] = json.dumps(metadata)
+    helper = H5EstimatorHelper('test.h5', 'basic')
+    for i in range(nblock):
+        helper.push(data[i], "energies")
+        helper.increment()
+
+    data = analyse_estimates(['test.h5'], start_time=0)
+    assert np.allclose(
+            data['ETotal'].values,
+            [4.8279208658716e-01]
+            )
+    assert np.allclose(
+            data['ETotal_ac'].values,
+            [4.832190780587988e-01]
+            )
+    assert np.allclose(
+            data['ETotal_error'].values[0],
+            [1.1124618641309e-02]
+            )
+    assert np.allclose(
+            data['ETotal_error_ac'].values,
+            [1.301950758507343e-02]
+            )
+
+@pytest.mark.unit
+def test_analyse_estimates_textfile():
+    np.random.seed(7)
+    nestim = 11
+    nblock = 500
+    data = np.random.random((nblock, nestim)) + 1j*np.random.random((nblock, nestim))
+    header = [
+        "Iteration",
+        "WeightFactor",
+        "Weight",
+        "ENumer",
+        "EDenom",
+        "ETotal",
+        "E1Body",
+        "E2Body",
+        "EHybrid",
+        "Overlap",
+        "Time",
+    ]
+    # fake some data
+    with open('test.dat', 'w') as f:
+        f.write(' '.join(h for h in header) + '\n')
+        for i in range(nblock):
+            f.write(' '.join("{:13.10e}".format(val.real) for val in data[i]) + '\n')
+        f.write("# End Time\n")
+
+    data = reblock_minimal(['test.dat'], start_block=1)
+
+    assert np.allclose(
+            data['ETotal_ac'].values,
+            [4.832190780587988e-01]
+            )
+    assert np.allclose(
+            data['ETotal_error_ac'].values,
+            [1.301950758507343e-02]
+            )
+
+def teardown_module():
+    cwd = os.getcwd()
+    files = ["test.h5", "test.dat"]
+    for f in files:
+        try:
+            os.remove(cwd + "/" + f)
+        except OSError:
+            pass

--- a/ipie/utils/io.py
+++ b/ipie/utils/io.py
@@ -17,7 +17,7 @@ def format_fixed_width_strings(strings):
 
 
 def format_fixed_width_floats(floats):
-    return " ".join("{: .10e}".format(f) for f in floats)
+    return " ".join("{: .16e}".format(f) for f in floats)
 
 
 def read_fortran_complex_numbers(filename):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 mpi4py >= 3.0.0
 bigmpi4py
 numba
+pyblock

--- a/tools/reblock.py
+++ b/tools/reblock.py
@@ -15,7 +15,11 @@ _script_dir = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(_script_dir, "analysis"))
 import glob
 
-from ipie.analysis.blocking import analyse_estimates, average_fp
+from ipie.analysis.blocking import (
+        analyse_estimates,
+        reblock_minimal,
+        average_fp
+        )
 from ipie.analysis.extraction import extract_data_sets
 
 
@@ -43,6 +47,15 @@ def parse_args(args):
         help="Imaginary time in a.u. after which we " "gather statistics.  Default: 0",
     )
     parser.add_argument(
+        "-b",
+        "--block-start",
+        type=int,
+        dest="block_start",
+        default=0,
+        help="Simulation block to start blocking analysis from (equilibration "
+        "time): Default 0",
+    )
+    parser.add_argument(
         "-m",
         "--multi-sim",
         action="store_true",
@@ -57,6 +70,13 @@ def parse_args(args):
         default=False,
         dest="free_proj",
         help="Free projection error analysis using mulitple" " simulations",
+    )
+    parser.add_argument(
+        "--legacy",
+        action="store_true",
+        default=False,
+        dest="legacy",
+        help="Perform legacy heavyweight analysis.",
     )
     parser.add_argument(
         "-t",
@@ -119,7 +139,7 @@ def main(args):
         data = extract_data_sets(files, "basic", "energies")
         res = average_fp(data)
         print(res.to_string(index=False))
-    else:
+    elif options.legacy:
         analyse_estimates(
             files,
             start_time=options.start_time,
@@ -127,6 +147,13 @@ def main(args):
             av_tau=options.av_tau,
             verbose=options.verbose,
         )
+    else:
+        results = reblock_minimal(
+            files,
+            start_block=options.block_start,
+            verbose=options.verbose,
+        )
+        print(results.to_string(index=False))
 
 
 if __name__ == "__main__":

--- a/tools/reblock.py
+++ b/tools/reblock.py
@@ -140,20 +140,24 @@ def main(args):
         res = average_fp(data)
         print(res.to_string(index=False))
     elif options.legacy:
-        analyse_estimates(
+        res = analyse_estimates(
             files,
             start_time=options.start_time,
             multi_sim=options.multi_sim,
             av_tau=options.av_tau,
             verbose=options.verbose,
         )
+        fmt = lambda x: "{:13.8f}".format(x)
+        print(res.to_string(index=False, float_format=fmt))
     else:
         results = reblock_minimal(
             files,
             start_block=options.block_start,
             verbose=options.verbose,
         )
+        fmt = lambda x: "{:13.8f}".format(x)
         print(results.to_string(index=False))
+        print(res.to_string(index=False, float_format=fmt))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Small addition to avoid analysing hdf5 file and instead analyse the raw stdout text file. Data extraction is faster and avoids any issues with hdf5 when trying to analyse in the middle of a calculation.

I did notice the script seems slower than it ought to be which looks to be package import related. Worth revisiting. 