### PR TITLE
Runtime dependent bug for GPU chunking fixed

### DIFF
--- a/ipie/propagation/generic.py
+++ b/ipie/propagation/generic.py
@@ -275,14 +275,34 @@ class GenericContinuous(object):
         for icycle in range(handler.ssize - 1):
             for isend, sender in enumerate(handler.senders):
                 if srank == isend:
+                    if iscupy:
+                        import cupy
+                        xshifted_send = cupy.asnumpy(xshifted_send)
+                        VHS_send = cupy.asnumpy(VHS_send)
+
                     handler.scomm.Send(
                         xshifted_send, dest=handler.receivers[isend], tag=1
                     )
                     handler.scomm.Send(VHS_send, dest=handler.receivers[isend], tag=2)
+
+                    if iscupy:
+                        import cupy
+                        xshifted_send = cupy.asarray(xshifted_send)
+                        VHS_send = cupy.asarray(VHS_send)
                 elif srank == handler.receivers[isend]:
                     sender = where(handler.receivers == srank)[0]
+                    if iscupy:
+                        import cupy
+                        xshifted_recv = cupy.asnumpy(xshifted_recv)
+                        VHS_recv = cupy.asnumpy(VHS_recv)
+
                     handler.scomm.Recv(xshifted_recv, source=sender, tag=1)
                     handler.scomm.Recv(VHS_recv, source=sender, tag=2)
+                    
+                    if iscupy:
+                        import cupy
+                        xshifted_recv = cupy.asarray(xshifted_recv)
+                        VHS_recv = cupy.asarray(VHS_recv)
             handler.scomm.barrier()
             # prepare sending
             VHS_send = (
@@ -294,10 +314,22 @@ class GenericContinuous(object):
 
         for isend, sender in enumerate(handler.senders):
             if handler.scomm.rank == sender:  # sending 1 xshifted to 0 xshifted_buf
+                if iscupy:
+                    import cupy
+                    VHS_send = cupy.asnumpy(VHS_send)
                 handler.scomm.Send(VHS_send, dest=handler.receivers[isend], tag=1)
+                if iscupy:
+                    import cupy
+                    VHS_send = cupy.asarray(VHS_send)
             elif srank == handler.receivers[isend]:
                 sender = where(handler.receivers == srank)[0]
+                if iscupy:
+                    import cupy
+                    VHS_recv = cupy.asnumpy(VHS_recv)
                 handler.scomm.Recv(VHS_recv, source=sender, tag=1)
+                if iscupy:
+                    import cupy
+                    VHS_recv = cupy.asarray(VHS_recv)
 
         VHS_recv = (
             self.isqrt_dt


### PR DESCRIPTION
Runtime dependent bug for GPU chunking fixed
The fix was to move GPU arrays to CPU before communicating via MPI.
This means that we can't benefit from GPU-to-GPU direct communications. This must be revisited at some point.