### PR TITLE
Use mo_occ for SD trials.

### DIFF
--- a/ipie/utils/from_pyscf.py
+++ b/ipie/utils/from_pyscf.py
@@ -111,11 +111,11 @@ def write_wavefunction_from_mo_coeff(
     else:
         if uhf:
             # HP: Assuming we are working in the alpha orbital basis, and write the beta orbitals as LCAO of alpha orbitals
-            # Frozen core is broken
             I = numpy.identity(nmo, dtype=numpy.float64)
-            wfna = I[:, mo_occ[0][num_frozen_core:]]
+            wfna = I[:, mo_occ[0][num_frozen_core:]>0]
             Xinv = scipy.linalg.pinv(X[:, num_frozen_core:])
-            wfnb = numpy.dot(Xinv, mo_coeff[1])[:, mo_occ[1]]
+            wfnb = numpy.dot(Xinv, mo_coeff[1])[:, num_frozen_core:]
+            wfnb = wfnb[:, mo_occ[1][num_frozen_core:]>0]
             write_wavefunction([wfna, wfnb], filename=filename)
         elif rohf:
             I = numpy.identity(nmo, dtype=numpy.float64)

--- a/ipie/utils/from_pyscf.py
+++ b/ipie/utils/from_pyscf.py
@@ -113,7 +113,7 @@ def write_wavefunction_from_mo_coeff(
             # HP: Assuming we are working in the alpha orbital basis, and write the beta orbitals as LCAO of alpha orbitals
             # Frozen core is broken
             I = numpy.identity(nmo, dtype=numpy.float64)
-            wfna = I[:, mo_occ[0]]
+            wfna = I[:, mo_occ[0][num_frozen_core:]]
             Xinv = scipy.linalg.pinv(X[:, num_frozen_core:])
             wfnb = numpy.dot(Xinv, mo_coeff[1])[:, mo_occ[1]]
             write_wavefunction([wfna, wfnb], filename=filename)
@@ -121,14 +121,13 @@ def write_wavefunction_from_mo_coeff(
             I = numpy.identity(nmo, dtype=numpy.float64)
             _occ_a = mo_occ > 0
             _occ_b = mo_occ > 1
-            wfna = I[:, _occ_a].copy()
-            wfnb = I[:, _occ_b].copy()
+            wfna = I[:, _occ_a[num_frozen_core:]].copy()
+            wfnb = I[:, _occ_b[num_frozen_core:]].copy()
             write_wavefunction([wfna, wfnb], filename=filename)
         else:
             # Assuming we are working in MO basis, only works for RHF, ROHF trials.
-            norb = mo_coeff.shape[1]
-            I = numpy.identity(norb, dtype=numpy.float64)
-            wfna = I[:, mo_occ]
+            I = numpy.identity(nmo, dtype=numpy.float64)
+            wfna = I[:, mo_occ[num_frozen_core:]]
             write_wavefunction(wfna, filename=filename)
 
 def generate_integrals(mol, hcore, X, chol_cut=1e-5, verbose=False, cas=None):

--- a/ipie/utils/from_pyscf.py
+++ b/ipie/utils/from_pyscf.py
@@ -36,6 +36,7 @@ def gen_ipie_input_from_pyscf_chk(
     hcore = scf_data["hcore"]
     ortho_ao_mat = scf_data['X']
     mo_coeffs = scf_data['mo_coeff']
+    mo_occ = scf_data['mo_occ']
     if ortho_ao:
         basis_change_matrix = ortho_ao_mat
     else:
@@ -67,12 +68,14 @@ def gen_ipie_input_from_pyscf_chk(
         occb = scf_data['occb']
         write_wavefunction((ci_coeffs, occa, occb), wfn_file, nelec)
     else:
-        write_wavefunction_from_mo_coeff(mo_coeffs, basis_change_matrix,
+        write_wavefunction_from_mo_coeff(mo_coeffs, mo_occ, basis_change_matrix,
                 wfn_file, nelec, num_frozen_core=num_frozen_core)
+
 
 
 def write_wavefunction_from_mo_coeff(
         mo_coeff: Union[list, numpy.ndarray],
+        mo_occ: Union[list, numpy.ndarray],
         X: numpy.ndarray,
         filename: str,
         nelec: tuple,
@@ -93,43 +96,44 @@ def write_wavefunction_from_mo_coeff(
         Xinv = scipy.linalg.inv(X)
         if uhf:
             # We are assuming C matrix is energy ordered.
-            wfna = numpy.dot(Xinv, mo_coeff[0])[:, :nalpha]
-            wfnb = numpy.dot(Xinv, mo_coeff[1])[:, :nbeta]
+            wfna = numpy.dot(Xinv, mo_coeff[0])[:, mo_occ[0]>0]
+            wfnb = numpy.dot(Xinv, mo_coeff[1])[:, mo_occ[1]>0]
             write_wavefunction([wfna, wfnb], filename=filename)
         elif rohf:
-            wfna = numpy.dot(Xinv, mo_coeff)[:, :nalpha]
-            wfnb = numpy.dot(Xinv, mo_coeff)[:, :nbeta]
+            _occ_a = mo_occ > 0
+            _occ_b = mo_occ > 1
+            wfna = numpy.dot(Xinv, mo_coeff)[:, _occ_a]
+            wfnb = numpy.dot(Xinv, mo_coeff)[:, _occ_b]
             write_wavefunction([wfna, wfnb], filename=filename)
         else:
-            wfna = numpy.dot(Xinv, mo_coeff)[:, :nalpha]
+            wfna = numpy.dot(Xinv, mo_coeff)[:, mo_occ]
             write_wavefunction(wfna, filename=filename)
     else:
         if uhf:
             # HP: Assuming we are working in the alpha orbital basis, and write the beta orbitals as LCAO of alpha orbitals
+            # Frozen core is broken
             I = numpy.identity(nmo, dtype=numpy.float64)
-            wfna = I[:, :nalpha]
+            wfna = I[:, mo_occ[0]]
             Xinv = scipy.linalg.pinv(X[:, num_frozen_core:])
-            wfnb = numpy.dot(Xinv, mo_coeff[1])[:, :nbeta]
+            wfnb = numpy.dot(Xinv, mo_coeff[1])[:, mo_occ[1]]
             write_wavefunction([wfna, wfnb], filename=filename)
         elif rohf:
             I = numpy.identity(nmo, dtype=numpy.float64)
-            wfna = I[:, :nalpha]
-            Xinv = scipy.linalg.pinv(X[:, num_frozen_core:])
-            wfnb = numpy.dot(Xinv, mo_coeff)[:, :nbeta]
+            _occ_a = mo_occ > 0
+            _occ_b = mo_occ > 1
+            wfna = I[:, _occ_a].copy()
+            wfnb = I[:, _occ_b].copy()
             write_wavefunction([wfna, wfnb], filename=filename)
         else:
             # Assuming we are working in MO basis, only works for RHF, ROHF trials.
             norb = mo_coeff.shape[1]
             I = numpy.identity(norb, dtype=numpy.float64)
-            wfna = I[:, :nalpha]
+            wfna = I[:, mo_occ]
             write_wavefunction(wfna, filename=filename)
-
 
 def generate_integrals(mol, hcore, X, chol_cut=1e-5, verbose=False, cas=None):
     # Unpack SCF data.
     # Step 1. Rotate core Hamiltonian to orthogonal basis.
-    if verbose:
-        print(" # Transforming hcore and eri to ortho AO basis.")
     if len(X.shape) == 2:
         h1e = numpy.dot(X.T, numpy.dot(hcore, X))
     elif len(X.shape) == 3:

--- a/ipie/utils/from_pyscf.py
+++ b/ipie/utils/from_pyscf.py
@@ -127,7 +127,7 @@ def write_wavefunction_from_mo_coeff(
         else:
             # Assuming we are working in MO basis, only works for RHF, ROHF trials.
             I = numpy.identity(nmo, dtype=numpy.float64)
-            wfna = I[:, mo_occ[num_frozen_core:]]
+            wfna = I[:, mo_occ[num_frozen_core:]>0]
             write_wavefunction(wfna, filename=filename)
 
 def generate_integrals(mol, hcore, X, chol_cut=1e-5, verbose=False, cas=None):

--- a/ipie/utils/tests/test_from_pyscf.py
+++ b/ipie/utils/tests/test_from_pyscf.py
@@ -151,6 +151,13 @@ def test_frozen_uhf():
     mc = mcscf.CASSCF(mf, 13, (3,1))
     h1_eff_ref, ecore = mc.get_h1eff()
     assert efzc == pytest.approx(ecore, 1e-3)
+    gen_ipie_input_from_pyscf_chk("scf.chk", hamil_file="afqmc.h5",
+            verbose=False, num_frozen_core=ncore)
+    wfn = read_wavefunction("wavefunction.h5")
+    assert wfn[0][0].shape[-1] == mol.nelec[0] - 1
+    assert wfn[0][1].shape[-1] == mol.nelec[1] - 1
+    assert wfn[1][0].shape[-1] == mol.nelec[0] - 1
+    assert wfn[1][1].shape[-1] == mol.nelec[1] - 1
 
 @pytest.mark.unit
 @pytest.mark.skipif(no_pyscf, reason="pyscf not found.")
@@ -178,6 +185,13 @@ def test_frozen_rohf():
     h1e, chol, efzc = freeze_core(h1e, chol, enuc, np.array([mf.mo_coeff, mf.mo_coeff]), ncore)
     assert efzc == pytest.approx(ecore)
     assert np.allclose(h1_eff_ref, h1e_eff, atol=1e-12, rtol=1e-8)
+    gen_ipie_input_from_pyscf_chk("scf.chk", hamil_file="afqmc.h5",
+            verbose=False, num_frozen_core=ncore)
+    wfn = read_wavefunction("wavefunction.h5")
+    assert wfn[0][0].shape[-1] == mol.nelec[0] - 1
+    assert wfn[0][1].shape[-1] == mol.nelec[1] - 1
+    assert wfn[1][0].shape[-1] == mol.nelec[0] - 1
+    assert wfn[1][1].shape[-1] == mol.nelec[1] - 1
 
 
 def teardown_module(self):


### PR DESCRIPTION
Fixes #159. Previously we assumed lowest N MOs were occupied for SD trials. Use mo_occ from chkpoint file instead to account for different occupations. Also added some more unit tests to catch this.