### PR TITLE
Automatically detect underlying active space in CAS trial

### DIFF
--- a/ipie/estimators/tests/test_generic_phmsd.py
+++ b/ipie/estimators/tests/test_generic_phmsd.py
@@ -934,16 +934,10 @@ def test_kernels_energy_active_space():
     wfn, init = get_random_phmsd(7, 7, nact, ndet=5000, init=True)
     ci, occa, occb = wfn
     core = [0, 1]
-    with_core_a = [
-        numpy.array(core + [orb + 2 for orb in oa], dtype=numpy.int32) for oa in occa
-    ]
-    with_core_b = [
-        numpy.array(core + [orb + 2 for orb in ob], dtype=numpy.int32) for ob in occb
-    ]
     wfn_2 = (
         ci[::50],
-        with_core_a[::50],
-        with_core_b[::50],
+        occa[::50],
+        occb[::50],
     )  # Get high excitation determinants too
 
     trial_ref = MultiSlater(
@@ -1216,17 +1210,10 @@ def test_phmsd_local_energy_active_space():
     )
     wfn, init = get_random_phmsd(7, 7, nact, ndet=5000, init=True)
     ci, occa, occb = wfn
-    core = [0, 1]
-    with_core_a = [
-        numpy.array(core + [orb + 2 for orb in oa], dtype=numpy.int32) for oa in occa
-    ]
-    with_core_b = [
-        numpy.array(core + [orb + 2 for orb in ob], dtype=numpy.int32) for ob in occb
-    ]
     wfn_2 = (
         ci[::50],
-        with_core_a[::50],
-        with_core_b[::50],
+        occa[::50],
+        occb[::50],
     )  # Get high excitation determinants too
 
     trial_ref = MultiSlater(
@@ -1235,7 +1222,7 @@ def test_phmsd_local_energy_active_space():
         wfn_2,
         options={
             "wicks": True,
-            "optimized": True,
+            "optimized": False,
             "use_wicks_helper": False,
         },
     )
@@ -1270,7 +1257,7 @@ def test_phmsd_local_energy_active_space():
     walker_batch_test.phia = walker_batch_ref.phia.copy()
     walker_batch_test.phib = walker_batch_ref.phib.copy()
     walker_batch_test.ovlp = walker_batch_ref.ovlp
-    greens_function_multi_det_wicks_opt(walker_batch_ref, trial_ref)
+    greens_function_multi_det_wicks(walker_batch_ref, trial_ref)
     greens_function_multi_det_wicks_opt(walker_batch_test, trial_test)
     assert numpy.allclose(walker_batch_ref.Ga, walker_batch_test.Ga)
     assert numpy.allclose(walker_batch_test.Ghalfa, walker_batch_ref.Ghalfa)
@@ -1282,7 +1269,7 @@ def test_phmsd_local_energy_active_space():
     # assert numpy.allclose(walker_batch_test.CIa, walker_batch_ref.CIa)
     # assert numpy.allclose(walker_batch_test.CIb, walker_batch_ref.CIb)
     assert trial_ref.nfrozen != trial_test.nfrozen
-    e_wicks_opt = local_energy_multi_det_trial_wicks_batch_opt(
+    e_wicks_opt = local_energy_multi_det_trial_wicks_batch(
         system, ham, walker_batch_ref, trial_ref
     )
     e_wicks_opt_act = local_energy_multi_det_trial_wicks_batch_opt(
@@ -1401,17 +1388,17 @@ def test_phmsd_local_energy_active_space_non_aufbau():
     occb[2] = tmp
     core = [0, 1]
     ci, occa, occb = wfn
-    with_core_a = numpy.array(
-        [numpy.array(core + [orb + 2 for orb in oa], dtype=numpy.int32) for oa in occa]
-    )
-    with_core_b = numpy.array(
-        [numpy.array(core + [orb + 2 for orb in ob], dtype=numpy.int32) for ob in occb]
-    )
+    # with_core_a = numpy.array(
+        # [numpy.array(core + [orb + 2 for orb in oa], dtype=numpy.int32) for oa in occa]
+    # )
+    # with_core_b = numpy.array(
+        # [numpy.array(core + [orb + 2 for orb in ob], dtype=numpy.int32) for ob in occb]
+    # )
     nskip = 10
     wfn_2 = (
         ci[::nskip],
-        with_core_a[::nskip],
-        with_core_b[::nskip],
+        occa[::nskip],
+        occb[::nskip],
     )  # Get high excitation determinants too
     ci, occa, occb = wfn_2
     trial = MultiSlater(


### PR DESCRIPTION
Previously these were input options, but everything should be determined from the input.