### PR TITLE
Fix build requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
     runs-on:  ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ One of the easiest ways (if you are using pip to install ipie wheels) is via con
 
 which will just install the OpenMPI library. 
 We refer users to the mpi4py
-`documentation <https://mpi4py.readthedocs.io/en/stable/install.html>`_` for
+`documentation <https://mpi4py.readthedocs.io/en/stable/install.html>`_ for
 alternative ways of building mpi4py and the required MPI library.
 
 Further requirements are listed in requirements.txt.
@@ -75,7 +75,7 @@ Further requirements are listed in requirements.txt.
 GPU Support
 -----------
 Cupy is is required when running calculations on GPUs which
-can be install following the instructions `here <https://cupy.dev/>_` .
+can be install following the instructions `here <https://cupy.dev/>`_ .
 
 Cuda aware MPI may be installed via conda-forge.
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,13 @@ ipie currently supports:
 Installation
 ------------
 
-Clone the repository
+Linux and Mac OS wheels are available for installation via pip
+
+::
+
+    $ pip install ipie
+
+For develpment you can instead clone the repository
 
 ::
 
@@ -45,26 +51,33 @@ and run the following in the top-level ipie directory
 ::
 
     $ pip install -r requirements.txt
-    $ python setup.py build_ext --inplace
-    $ python setup.py install
-
-You may also need to set your PYTHONPATH appropriately.
+    $ pip install -e.
 
 Requirements
 ------------
 
-* python (>= 3.6)
-* numpy
-* scipy
-* h5py
-* mpi4py
-* cython
-* pandas
+ipie currently relies on MPI (via mpi4py) for parallelism and it is often the
+trickiest dependency to setup correctly.
 
-Minimum versions are listed in the requirements.txt.
-To run the tests you will need pytest.
-To perform error analysis you will also need `pyblock <https://github.com/jsspencer/pyblock>`_.
+One of the easiest ways (if you are using pip to install ipie wheels) is via conda:
 
+::
+
+    conda install openmpi
+
+which will just install the OpenMPI library. 
+We refer users to the mpi4py
+`documentation <https://mpi4py.readthedocs.io/en/stable/install.html>`_` for
+alternative ways of building mpi4py and the required MPI library.
+
+Further requirements are listed in requirements.txt.
+
+GPU Support
+-----------
+Cupy is is required when running calculations on GPUs which
+can be install following the instructions `here <https://cupy.dev/>_` .
+
+Cuda aware MPI may be installed via conda-forge.
 
 Running the Test Suite
 ----------------------

--- a/ipie/estimators/tests/test_generic_chunked.py
+++ b/ipie/estimators/tests/test_generic_chunked.py
@@ -1,4 +1,3 @@
-
 # Copyright 2022 The ipie Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,11 +21,14 @@ import pytest
 from mpi4py import MPI
 
 from ipie.estimators.generic import local_energy_cholesky_opt
-from ipie.estimators.local_energy_sd import (local_energy_single_det_batch,
-                                             local_energy_single_det_rhf_batch,
-                                             local_energy_single_det_uhf_batch)
-from ipie.estimators.local_energy_sd_chunked import \
-    local_energy_single_det_uhf_batch_chunked
+from ipie.estimators.local_energy_sd import (
+    local_energy_single_det_batch,
+    local_energy_single_det_rhf_batch,
+    local_energy_single_det_uhf_batch,
+)
+from ipie.estimators.local_energy_sd_chunked import (
+    local_energy_single_det_uhf_batch_chunked,
+)
 from ipie.hamiltonians.generic import Generic as HamGeneric
 from ipie.propagation.continuous import Continuous
 from ipie.systems.generic import Generic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "pip",
     "setuptools>=42",
     "wheel",
-    "numpy>=1.16.5",
+    "numpy>=1.20.0",
     "Cython>=0.29.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython >= 0.29.0
 h5py
-numpy >= 1.16.5
+numpy >= 1.20.0
 scipy >= 1.3.0
 pytest
 pandas

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     packages=find_packages(exclude=["examples", "docs", "tests", "tools", "setup.py"]),
     license="Apache 2.0",
     description="Python implementations of Imaginary-time Evolution algorithms",
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     scripts=[
         "bin/ipie",
         "tools/extract_dice.py",


### PR DESCRIPTION
Bumping minumum numpy version to 1.20 to fix cython / setup / wheel issues. This requirement means python3.6 is out which also would allow us to start using dataclasses introduced in 3.7. I dropped 3.7 from the ci matrix and included 3.10 as 3.7 is quite old too at this point.