### PR TITLE
Bump minimum h5py version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython >= 0.29.0
-h5py
+h5py >= 3.0.0
 numpy >= 1.20.0
 scipy >= 1.3.0
 pytest


### PR DESCRIPTION
Addresses #198 and does not affect #182 as it just specifies a minimum version not a specific 3.x.y.